### PR TITLE
Fix skyblock stats url

### DIFF
--- a/src/constants/app/app.js
+++ b/src/constants/app/app.js
@@ -8,6 +8,6 @@ export const APP = {
 	organizationUrl: "https://github.com/25karma",
 	ownerHypixelForumsUrl: "",
 	ownerUsername: "",
-	skyblockUrl: "https://sky.shiiyu.moe",
+	skyblockUrl: "https://sky.shiiyu.moe/stats",
 	suggestedPlayers: ["Technoblade", "gamerboy80", "Technoblade"],
 }


### PR DESCRIPTION
Before it showed 404 on skycrypt