### PR TITLE
Fix client state and cookie edge cases

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,11 +15,11 @@ function App() {
 				<Router basename={import.meta.env.BASE_URL}>
 					{MAINTENANCE.enabled ?
 						<Routes>
-							<Route default element={<MaintenancePage />}></Route>
+							<Route path="*" element={<MaintenancePage />}></Route>
 						</Routes>
 						:
 						<Routes>
-							<Route exact path="/" element={<Navigate replace to={pinnedPlayer ? `/search/${pinnedPlayer}` : '/frontpage'} />}></Route>
+							<Route path="/" element={<Navigate replace to={pinnedPlayer ? `/search/${pinnedPlayer}` : '/frontpage'} />}></Route>
 							{PAGES.map(p => <Route key={p.path} path={`/${p.path}/:slug`} element={<p.component />}></Route>)}
 							<Route path="/frontpage" element={<FrontPage />}></Route>
 							<Route path="/search/:slug" element={<SearchPage />}></Route>

--- a/src/components/AccordionList.jsx
+++ b/src/components/AccordionList.jsx
@@ -36,7 +36,16 @@ export function AccordionList({ cookie, accordionModule }) {
 			}
 		}
 		else {
-			const {list, showLine} = JSON.parse(json);
+			let list, showLine;
+			try {
+				({list, showLine} = JSON.parse(json));
+				if (!Array.isArray(list)) throw new Error('Invalid accordion cookie');
+				list = [...list];
+			} catch {
+				Cookies.remove(cookie);
+				return getCookie();
+			}
+
 			// Add any Accordions that were not found in the cookie data
 			let accordionNames = [...Object.keys(accordionModule), 'HorizontalLine'];
 			for (const name of accordionNames) {

--- a/src/components/ReactIcon.jsx
+++ b/src/components/ReactIcon.jsx
@@ -12,7 +12,11 @@ import { IconContext } from 'react-icons';
  */
 export function ReactIcon(props) {
 	const { icon, size, color, clickable } = props;
-	const className = `reacticon-${size || 'md'} ${clickable && 'reacticon-clickable'} ${color ? 'c-'+color : null}`;
+	const className = [
+		`reacticon-${size || 'md'}`,
+		clickable ? 'reacticon-clickable' : '',
+		color ? 'c-'+color : '',
+	].filter(Boolean).join(' ');
 	const Icon = icon === 'HypixelLogo' ? HypixelLogo : icon;
 
 	return (

--- a/src/constants/app/app.js
+++ b/src/constants/app/app.js
@@ -8,7 +8,7 @@ export const APP = {
 	organizationUrl: "https://github.com/25karma",
 	ownerHypixelForumsUrl: "",
 	ownerUsername: "",
-	skyblockUrl: "https://sky.shiiyu.moe/stats",
+	skyblockUrl: "https://sky.shiiiyu.moe/stats",
 	suggestedPlayers: ["Technoblade", "gamerboy80", "Technoblade"],
 	discordUrl: "",
 	announcement: {

--- a/src/hooks/useAPIContext.js
+++ b/src/hooks/useAPIContext.js
@@ -12,31 +12,46 @@ import { getClientHeaders, httpGet } from 'src/utils';
  */
 export function useAPIContext(slug, type) {
 	const { APIData, setAPIData } = useContext(APIContext);
-	// Monitors the state of the API fetch, if a slug is provided
-	const [fetchStatus, setFetchStatus] = useState(false);
+	const requestKey = slug ? `${type}/${slug}` : null;
+	const [loadedRequestKey, setLoadedRequestKey] = useState(null);
+
 	useEffect(() => {
+		if (!slug) return;
+
+		let ignore = false;
+
 		async function fetchFromAPI() {
-			const href = window.location.href;
 			const url = `${APP.apiUrl}/${type}/${slug}`;
-			return httpGet(url, { headers: await getClientHeaders() })
-				.then((response) => response.json())
-				.then((json) => {
-					if(window.location.href === href) {
-						setAPIData(json);
-						setFetchStatus(true);
-					}
-				});
-		}
-		if (slug) {
+
 			setAPIData({});
-			fetchFromAPI();
+			setLoadedRequestKey(null);
+
+			try {
+				const response = await httpGet(url, { headers: await getClientHeaders() });
+				const json = await response.json();
+				if (!ignore) {
+					setAPIData(json);
+					setLoadedRequestKey(requestKey);
+				}
+			} catch {
+				if (!ignore) {
+					setAPIData({ success: false, reason: 'UNKNOWN', slug });
+					setLoadedRequestKey(requestKey);
+				}
+			}
 		}
-	}, [slug, type, setAPIData])
+
+		fetchFromAPI();
+
+		return () => {
+			ignore = true;
+		};
+	}, [slug, type, requestKey, setAPIData])
 	
 	// If we are fetching new data from the API, we don't want to return the old data from the context
 	// We return an empty JS object until the new data has been fetched
 	if (slug) {
-		return fetchStatus ? APIData : {};
+		return loadedRequestKey === requestKey ? APIData : {};
 	}
 	else {
 		return APIData;

--- a/src/pages/FrontPage/components/RecentSearches.jsx
+++ b/src/pages/FrontPage/components/RecentSearches.jsx
@@ -1,20 +1,16 @@
 import React, { useEffect, useRef, useState } from 'react';
-import Cookies from 'js-cookie';
 import { MdMoreHoriz } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import { Button, MinecraftText, ReactIcon, Tippy } from 'src/components';
-import { APP, COOKIES } from 'src/constants/app';
+import { APP } from 'src/constants/app';
+import { getRecentSearches } from 'src/utils';
 
 /**
  * Renders JSX containing recent searches if there are any
  * If there are none, renders a suggestion
  */
 export function RecentSearches() {
-	let cookie = Cookies.get(COOKIES.recentSearches);
-	if (cookie === undefined) {
-		cookie = '[]';
-	}
-	const array = JSON.parse(cookie);
+	const array = getRecentSearches();
 
 	// Stores whether to show all recent searches or only the first line
 	const [showAllRecents, setShowAllRecents] = useState(false);

--- a/src/utils/js-cookie.js
+++ b/src/utils/js-cookie.js
@@ -2,6 +2,23 @@ import Cookies from 'js-cookie';
 import { COOKIES } from 'src/constants/app';
 import { default0 } from './index';
 
+export function getRecentSearches() {
+	let cookie = Cookies.get(COOKIES.recentSearches);
+	if (cookie === undefined) {
+		return [];
+	}
+
+	try {
+		const array = JSON.parse(cookie);
+		if (Array.isArray(array)) return array;
+	} catch {
+		// Fall through and reset the bad cookie below.
+	}
+
+	Cookies.remove(COOKIES.recentSearches);
+	return [];
+}
+
 /**
  * Adds commas to a large number and strips decimal places to user preference
  *
@@ -24,11 +41,7 @@ export function formatNum(num) {
  */
 export function pushToRecentSearches(ele) {
 	const str = String(ele);
-	let cookie = Cookies.get(COOKIES.recentSearches);
-	if (cookie === undefined) {
-		cookie = '[]';
-	}
-	const array = JSON.parse(cookie);
+	const array = getRecentSearches();
 	const maxLength = 40;
 	
 	// The new player name is put at the front of the queue


### PR DESCRIPTION
Fixes a few client-side edge cases I noticed while testing:

- keep pages in a loading state while a new API request is still in flight
- reset bad recent-search and accordion cookies instead of crashing the page
- make maintenance mode catch every route
- avoid bogus `false` and `null` classes on icons